### PR TITLE
fixed issue that getSocketIndex returned wrong fd

### DIFF
--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -42,7 +42,7 @@ private:
         void setNonBlocking(int fd);
         void cleanup();
         void timeout_clients();
-        std::optional<int> getSocketIndex(int fd) const;
+        std::optional<size_t> getSocketIndex(int fd) const;
 
         void send_cgi_responses(void);
         void epoll_event_loop(int num_events);

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -393,19 +393,13 @@ void Server::send_cgi_responses()
     }
 }
 
-std::optional<int> Server::getSocketIndex(int fd) const
+std::optional<size_t> Server::getSocketIndex(int fd) const
 {
-    std::optional<int> socket_index;
-
-    for (const auto& it: m_listening_sockets)
-    {
-        const auto& server_sockets = it.getServerSockets();
-        auto pos = std::find_if(server_sockets.begin(), server_sockets.end(), [fd](int sock){ return fd == sock ;});
-        if (pos != server_sockets.end())
-        {
-            socket_index.emplace(std::distance(server_sockets.begin(), pos));
-            return socket_index;
-        }
+    for (size_t i = 0; i < m_listening_sockets.size(); ++i) 
+	{
+        const auto& server_sockets = m_listening_sockets[i].getServerSockets();
+        if (std::find(server_sockets.begin(), server_sockets.end(), fd) != server_sockets.end())
+            return i;
     }
-    return socket_index;
+    return std::nullopt;
 }


### PR DESCRIPTION
fix #55 

getSocketIndex returned position of FD of a single socket (f.e. fd's to handle in port 1051). it shouldve returned the index of m_listening_sockets (which are the listening sockets) 

event loop expects index of m_listening_sockets!